### PR TITLE
fix: simulcast vp8

### DIFF
--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -401,7 +401,6 @@ func (b *Buffer) calc(pkt []byte, arrivalTime int64) {
 	if diff >= reportDelta {
 		br := (8 * b.bitrateHelper * uint64(reportDelta)) / uint64(diff)
 		atomic.StoreUint64(&b.bitrate, br)
-		b.feedbackCB(b.getRTCP())
 		b.lastReport = arrivalTime
 		b.bitrateHelper = 0
 	}

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -354,7 +354,6 @@ func (w *WebRTCReceiver) writeRTP(layer int) {
 				if pkt.KeyFrame {
 					w.Lock()
 					for idx, dt := range w.pendingTracks[layer] {
-						w.deleteDownTrack(dt.CurrentSpatialLayer(), dt.id)
 						w.storeDownTrack(layer, dt)
 						dt.SwitchSpatialLayerDone(int32(layer))
 						w.pendingTracks[layer][idx] = nil


### PR DESCRIPTION
Avoid layer deleted in change.
Remove feedback (client calculated outgoing bitrate). it makes the vp8 simulcast freeze at high quality (f layer).
@GRVYDEV 